### PR TITLE
fix: 自定义域名 base 路径修正

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,8 +3,7 @@ import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://muliminty.github.io',
-  base: '/home/',
+  site: 'https://muliminty.site',
   output: 'static',
   integrations: [react(), sitemap()],
   prefetch: {


### PR DESCRIPTION
## Summary
site 域名从 `muliminty.github.io` 改为 `muliminty.site`，去掉 `base: /home/`。
自定义域名会将站点映射到域名根路径，`/home/` 前缀导致所有资源 404。

## Changes
- `astro.config.ts`: site → `https://muliminty.site`，移除 base

🤖 Generated with [Claude Code](https://claude.com/claude-code)