### PR TITLE
fix: 去掉所有硬编码 /home/ 路径前缀

### DIFF
--- a/src/components/CodeProfile.astro
+++ b/src/components/CodeProfile.astro
@@ -50,7 +50,7 @@ try {
 
     const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const regex = new RegExp(`(?<![\\w>])(${escaped})(?![\\w<])`, 'g');
-    const iconPath = `/home/tech-icons/${name}.svg`;
+    const iconPath = `/tech-icons/${name}.svg`;
     html = html.replace(regex, () => {
       return `<span class="code-tech" style="--tc:${color}"><img src="${iconPath}" class="tech-logo" alt="${name}" />${name}</span>`;
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export const siteConfig = {
   author: 'muliminty',
   github: 'https://github.com/muliminty',
   email: 'muliminty@example.com',
-  defaultOgImage: '/home/default-og.png',
+  defaultOgImage: '/default-og.png',
   projects: [
     { name: 'home', url: 'https://github.com/muliminty/home', description: '个人公开时间线站点' },
     { name: 'dotfiles', url: 'https://github.com/muliminty/dotfiles', description: 'macOS 开发环境配置' },

--- a/src/config/terminal.config.js
+++ b/src/config/terminal.config.js
@@ -88,7 +88,7 @@ export const terminalConfig = {
   
   links: [
     { name: 'GitHub', url: 'https://github.com/Muliminty', icon: '🐱' },
-    { name: '主页', url: 'https://muliminty.github.io/home/', icon: '📝' },
+    { name: '主页', url: 'https://muliminty.site/', icon: '📝' },
     { name: '笔记', url: 'https://muliminty.github.io/Muliminty-Note/', icon: '📝' },
     { name: '博客', url: 'https://muliminty.github.io/', icon: '📖' },
     { name: '邮箱', url: 'mailto:muliminty@qq.com', icon: '📧' },
@@ -153,7 +153,7 @@ export const terminalConfig = {
   
   deploy: {
     // GitHub Pages 部署路径（如果是根目录则设为 '/'）
-    basePath: '/home/',
+    basePath: '/',
     // 构建输出目录
     outputDir: 'dist',
   },

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -17,8 +17,8 @@ const fullTitle = title === siteTitle ? title : `${title} — ${siteTitle}`;
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/home/favicon-32.png" />
-  <link rel="icon" type="image/png" sizes="128x128" href="/home/favicon-128.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="128x128" href="/favicon-128.png" />
   <title>{fullTitle}</title>
   <meta name="description" content={description || '一个前端开发者的公开时间线'} />
   <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site).href} />


### PR DESCRIPTION
## Summary
自定义域名 `muliminty.site` 已将站点映射到根路径，所有硬编码的 `/home/` 前缀导致资源 404。

## Changes
- `BaseLayout.astro`: favicon 路径
- `CodeProfile.astro`: tech-icons 路径
- `config.ts`: defaultOgImage 路径
- `terminal.config.js`: 主页 URL + basePath

🤖 Generated with [Claude Code](https://claude.com/claude-code)